### PR TITLE
make metadata valid for intermediate tool tutorial

### DIFF
--- a/tutorials/context-dependent-tool-tutorial.md
+++ b/tutorials/context-dependent-tool-tutorial.md
@@ -1,6 +1,6 @@
 ---
 layout: doc
-title: Intermediate Tool Tutorial: Context-dependent Tools
+title: Creating Context-Dependent Tools
 permalink: /docs/tutorials/context-dependent-tools
 ---
 


### PR DESCRIPTION
I think the colon in the title was messing up it how it was getting parsed, so the permalink wasn't parsing either. Looks like it is correctly a table now